### PR TITLE
Bump autoform version

### DIFF
--- a/materialize-chips.js
+++ b/materialize-chips.js
@@ -31,18 +31,22 @@ Template.afMaterializeChips.onRendered(function() {
   var params = this.data.atts;
   template.autorun(function () {
     var data = Template.currentData();
-    template.$('.chips-autoform').material_chip({
-      data: data.value,
-      placeholder: params.placeholder,
-      secondaryPlaceholder:  params.secondaryPlaceholder
-    });
     if (params && params.autocompleteOptions) {
       template.$('.chips-autoform').material_chip({
+        data: data.value,
+        placeholder: params.placeholder,
+        secondaryPlaceholder: params.secondaryPlaceholder,
         autocompleteOptions: {
           limit: params.autocompleteOptions.limit,
           minLength: params.autocompleteOptions.minLength,
           data: params.autocompleteOptions.data()
         }
+      });
+    } else {
+      template.$('.chips-autoform').material_chip({
+        data: data.value,
+        placeholder: params.placeholder,
+        secondaryPlaceholder: params.secondaryPlaceholder
       });
     }
   });

--- a/materialize-chips.js
+++ b/materialize-chips.js
@@ -3,9 +3,12 @@ AutoForm.addInputType("materialize-chips", {
   valueIsArray: true,
   valueOut: function() {
     var ret = [];
-    this.material_chip('data').forEach(function(data){
-      ret.push(data.tag);
-    });
+    var datas = this.material_chip('data')
+    if (datas) {
+      datas.forEach(function(data){
+        ret.push(data.tag);
+      });
+    }
     return ret;
   },
   valueIn: function(val) {
@@ -31,12 +34,16 @@ Template.afMaterializeChips.onRendered(function() {
     template.$('.chips-autoform').material_chip({
       data: data.value,
       placeholder: params.placeholder,
-      secondaryPlaceholder:  params.secondaryPlaceholder,
-      autocompleteOptions: {
-        limit: params.autocompleteOptions.limit,
-        minLength: params.autocompleteOptions.minLength,
-        data: params.autocompleteOptions.data()
-      }
+      secondaryPlaceholder:  params.secondaryPlaceholder
     });
+    if (params && params.autocompleteOptions) {
+      template.$('.chips-autoform').material_chip({
+        autocompleteOptions: {
+          limit: params.autocompleteOptions.limit,
+          minLength: params.autocompleteOptions.minLength,
+          data: params.autocompleteOptions.data()
+        }
+      });
+    }
   });
 });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dguedry:autoform-materialize-chips',
-  version: '0.0.1',
+  version: '0.1.0',
   // Brief, one-line summary of the package.
   summary: 'Materialize Chips (Tags) input for Autoform',
   // URL to the Git repository containing the source code for this package.
@@ -11,7 +11,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use(['aldeed:autoform@4.0.0 || 5.0.0',
+  api.use(['aldeed:autoform@6.0.0',
           'templating@1.1.2',
           'blaze@2.3.0',
           'jquery@1.11.10'], 'client');


### PR DESCRIPTION
Right now the package is not compatible with Autoform 6.0.0
I am bumping the version of Autoform without making it compatible with 4.0.0 and 5.0.0 version of autoform. This is according to what is suggested in [Autoform Docs](https://github.com/aldeed/meteor-autoform#note-autoform-60). So am also bumping the package version.